### PR TITLE
DrawAreaBase: save memory usage while default and mail fonts are same

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -121,6 +121,7 @@ DrawAreaBase::DrawAreaBase( const std::string& url )
 #endif
     , m_ready_back_frame( false )
     , m_aafont_initialized( false )
+    , m_mailfont_initialized{ false }
     , m_strict_of_char( false )
     , m_configure_reserve( false )
     , m_configure_width( 0 )
@@ -424,8 +425,14 @@ void DrawAreaBase::init_font()
     }
 
     std::string mailfontname = CONFIG::get_fontname( m_defaultmailfontid );
-    if ( fontname.empty() ) mailfontname = fontname;
-    init_fontinfo( m_mailfont, mailfontname );
+    if( ! mailfontname.empty() && mailfontname != fontname ) {
+        m_mailfont_initialized = true;
+        init_fontinfo( m_mailfont, mailfontname );
+    }
+    else {
+        // メモリ節約のためデフォルトとメール欄のフォントが同じときはデフォルトを利用する
+        m_mailfont_initialized = false;
+    }
 
     // layoutにフォントをセット
     m_font = &m_defaultfont;
@@ -2752,7 +2759,12 @@ char DrawAreaBase::get_layout_fontid( LAYOUT* layout )
         break;
 
     case FONT_MAIL:
-        return layout->node->fontid;
+        if( m_mailfont_initialized ) {
+            return layout->node->fontid; // メール欄などのフォント情報
+        }
+        else {
+            return m_defaultfontid; // デフォルトフォント情報
+        }
         break;
 
     case FONT_EMPTY: // フォントID未決定

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -181,9 +181,10 @@ namespace ARTICLE
         int m_defaultmailfontid;
         FONTINFO *m_font; // カレントフォント情報
         FONTINFO m_defaultfont; // デフォルトフォント情報
-        bool m_aafont_initialized;
         FONTINFO m_aafont; // AA用フォント情報
         FONTINFO m_mailfont; // メールフォント情報
+        bool m_aafont_initialized;
+        bool m_mailfont_initialized;
 
         // スレビューで文字幅の近似を厳密にするか
         bool m_strict_of_char;


### PR DESCRIPTION
スレビューのデフォルトとメール欄のフォントが同じときはデフォルトフォントだけ使うようにしてメモリ使用量を節約します。